### PR TITLE
Support prom-client 13 and 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        prom-client-version: [11, 12]
+        prom-client-version: [11, 12, 13, 14]
     runs-on: ubuntu-latest
     name: Build with Prom Client ${{matrix.prom-client-version}}
     steps:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,67 @@
+# Testing
+
+To test this library a helper app has been provided (`test.js`).
+
+## Testing procedure
+
+To test the application start the test application with `node test.js`. Then execute the below two curl commands.
+
+- `curl http://localhost:3000`
+- `curl http://localhost:3000/metrics`
+
+The latter endpoint should return metrics for the first curl command that you executed. A sample response has been
+included below for reference.
+
+```
+# HELP server_connections_total The total tcp socket connections created
+# TYPE server_connections_total counter
+server_connections_total{address="[::]:3000"} 3
+
+# HELP server_connections The current number connected tcp sockets
+# TYPE server_connections gauge
+server_connections{address="[::]:3000"} 1
+
+# HELP server_requests_in_flight The number of http requests in flight
+# TYPE server_requests_in_flight gauge
+server_requests_in_flight{address="[::]:3000"} 1
+
+# HELP server_unused_connections The current number of tcp sockets yet to be used
+# TYPE server_unused_connections gauge
+server_unused_connections{address="[::]:3000"} 0
+
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{method="GET",path="/metrics",code="200"} 1
+http_requests_total{method="GET",path="/",code="200"} 1
+
+# HELP http_request_duration_seconds The HTTP request latencies in seconds.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{le="0.005",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="0.01",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="0.025",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="0.05",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="0.1",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="0.25",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="0.5",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="1",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="2.5",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="5",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="10",method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="+Inf",method="GET",path="/metrics"} 1
+http_request_duration_seconds_sum{method="GET",path="/metrics"} 0.00317
+http_request_duration_seconds_count{method="GET",path="/metrics"} 1
+http_request_duration_seconds_bucket{le="0.005",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="0.01",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="0.025",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="0.05",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="0.1",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="0.25",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="0.5",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="1",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="2.5",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="5",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="10",method="GET",path="/"} 1
+http_request_duration_seconds_bucket{le="+Inf",method="GET",path="/"} 1
+http_request_duration_seconds_sum{method="GET",path="/"} 0.001569583
+http_request_duration_seconds_count{method="GET",path="/"} 1
+```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## 1.2.0+
+
+Prom Client 13 and 14 have been supported. No functionality changes have been made.
+
 ## 1.1.0+
 
-The npm library `prom-client` has been moved to be a peer dependency. This means that you will need to ensure that this is installed as well. As of 1.1.0 the peer dependency for prom client has been fixed at [v11, v12] as currently this library does not support greater than this without code change (i.e. v13+).
+The npm library `prom-client` has been moved to be a peer dependency. This means that you will need to ensure that this
+is installed as well. As of 1.1.0 the peer dependency for prom client has been fixed at [v11, v12] as currently this
+library does not support greater than this without code change (i.e. v13+).

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,13 @@
         "@types/node": "^18.15.10",
         "express": "^4.16.4",
         "prettier": "^1.16.4",
-        "prom-client": "^12.0.0",
+        "prom-client": "^14.2.0",
         "tslint": "^5.12.1",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.8.4"
       },
       "peerDependencies": {
-        "prom-client": ">=11 <=12"
+        "prom-client": ">=11 <=14"
       }
     },
     "node_modules/@types/node": {
@@ -697,9 +697,9 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
       "dev": true,
       "dependencies": {
         "tdigest": "^0.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/http-kit",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/http-kit",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/on-finished": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^18.15.10",
     "express": "^4.16.4",
     "prettier": "^1.16.4",
-    "prom-client": "^12.0.0",
+    "prom-client": "^14.2.0",
     "tslint": "^5.12.1",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^4.8.4"
@@ -31,6 +31,6 @@
     "path-to-regexp": "^3.0.0"
   },
   "peerDependencies": {
-    "prom-client": ">=11 <=12"
+    "prom-client": ">=11 <=14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-kit",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ const {
   createErrorMiddleware,
   createMetricsMiddleware,
   registerMetrics,
-  Router
+  Router,
 } = require("./dist");
 
 registerMetrics(register);
@@ -19,7 +19,7 @@ const app = express();
 app.use(createLoggingMiddleware(console));
 app.use(createMetricsMiddleware());
 
-app.get("/metrics", (req, res) => res.send(register.metrics()));
+app.get("/metrics", async (req, res) => res.send(await register.metrics()));
 
 const router = new Router();
 


### PR DESCRIPTION
__Change Summary__

- Added prom-client 13 and 14 to CI build testing
- Added prom-client 13 and 14 to the peer dependencies
- Updated prom-client dev dependency to v14 and updated test app to support promise `.metrics()` return
- Updated upgrading documentation to show support for new prom-client versions
- Added testing procedure document (see below)
- Updated version to 1.2.0

I have added the `TESTING.md` document to outline how to test this library as is a bit difficult to test in CI as you need to start and stop an app (probably can be done but will investigate later). I have just documented the current testing procedure for the people that follow (you can test this PR for yourself by using this document to test it out as well).